### PR TITLE
Update workshop name on Bioc website

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Bioc2020Anno
-Title: Package for Bioconductor 2020 annotation workshop
-Version: 0.5.9
+Title: Introduction to Bioconductor annotation resources
+Version: 0.6.0
 Authors@R: c(person("James", "MacDonald", role = c("aut", "cre"),
 	            email = "jmacdon@uw.edu"),
              person("Lori", "Shepherd", role = c("aut"),


### PR DESCRIPTION
The website automatically draws the name from the DESCRIPTION file. I realized I had an undesired name for my workshop on the website and I believe you might also. This change will update it.